### PR TITLE
Add zephyr framework to lpcxpresso55s69

### DIFF
--- a/boards/lpcxpresso55s69.json
+++ b/boards/lpcxpresso55s69.json
@@ -2,7 +2,10 @@
   "build": {
     "cpu": "cortex-m33",
     "f_cpu": "150000000L",
-    "mcu": "lpc55s69"
+    "mcu": "lpc55s69",
+    "zephyr": {
+      "variant": "lpcxpresso55s69_ns"
+    }
   },
   "connectivity": [
     "ethernet"
@@ -14,7 +17,8 @@
     ]
   },
   "frameworks": [
-    "mbed"
+    "mbed",
+    "zephyr"
   ],
   "name": "NXP LPCXpresso55S69",
   "upload": {


### PR DESCRIPTION
I made changes based on the similar 55S16 board file here. First commit here, so let me know if there's something missing!

Also, there's 2 additional variants for the board under zephyr

- lpcxpresso55s16_cpu0
- lpcxpresso55s16_cpu1

As I understand, I'll have to create different board files for these variants?